### PR TITLE
Add auto-specific down command for volume

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -229,8 +229,11 @@ public class RobotContainer {
         }
 
         private Command getStartCommand() {
-                return Commands.parallel(m_ShooterSubsystem.warmUpMotorToPercentCommand("Fast Speed"),
-                                m_AmpFlopper.ampFlopperDownCommand(), m_volume.putVolumeDown()).withTimeout(.25);
+                return Commands.parallel(
+                        m_ShooterSubsystem.warmUpMotorToPercentCommand("Fast Speed"),
+                        m_AmpFlopper.ampFlopperDownCommand(), 
+                        m_volume.putVolumeDownAuto()
+                ).withTimeout(.25);
         }
 
         /**

--- a/src/main/java/frc/robot/subsystems/VolumeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/VolumeSubsystem.java
@@ -48,7 +48,8 @@ public class VolumeSubsystem extends SubsystemBase {
   }
 
   public double getAngle() {
-    return encoder.getDistance();
+    double rawAngle = encoder.getDistance();
+    return (rawAngle + 180.0) % 360.0 - 180.0;
   }
 
   public void setMotor(double speed) {
@@ -67,8 +68,11 @@ public class VolumeSubsystem extends SubsystemBase {
   public Command putVolumeUp() {
     return Commands.startEnd(() -> setMotor(.75), () -> stopMotor(), this);
   }
-   public Command putVolumeDown() {
+  public Command putVolumeDown() {
     return Commands.startEnd(() -> setMotor(-.5), () -> stopMotor(), this);
+  }
+  public Command putVolumeDownAuto() {
+    return Commands.startEnd(() -> setMotor(-1.0), () -> stopMotor(), this);
   }
 
   public void setGoalAngle(double goalAngle) {


### PR DESCRIPTION
The volume wasn't folding out far enough at the start of auto (notes were hitting) so we made it run faster. But we didn't want to change the teleop control so we made a new command specifically for auto.

Also at one point in testing the volume angle became -360ish, which shouldn't be possible but it was happening. Rebooting the bot fixed this, but what if it happens during a match. So we added some modulo math to wrap the volume's angle to [-180, 180].